### PR TITLE
fix: modify vector_search signature

### DIFF
--- a/src/mcp_server_milvus/server.py
+++ b/src/mcp_server_milvus/server.py
@@ -89,6 +89,7 @@ class MilvusConnector:
         limit: int = 5,
         output_fields: Optional[list[str]] = None,
         metric_type: str = "COSINE",
+        filter_expr: Optional[str] = None, 
     ) -> list[dict]:
         """
         Perform vector similarity search on a collection.
@@ -112,7 +113,7 @@ class MilvusConnector:
                 search_params=search_params,
                 limit=limit,
                 output_fields=output_fields,
-
+                filter=filter_expr,
             )
             return results
         except Exception as e:
@@ -126,6 +127,7 @@ class MilvusConnector:
         limit: int = 5,
         output_fields: Optional[list[str]] = None,
         metric_type: str = "COSINE",
+        filter_expr: Optional[str] = None, 
     ) -> list[dict]:
         """
         Perform hybrid search combining vector similarity and attribute filtering.
@@ -138,6 +140,7 @@ class MilvusConnector:
             limit: Maximum number of results
             output_fields: Fields to return in results
             metric_type: Distance metric (COSINE, L2, IP)
+            filter_expr: Optional filter expression
         """
         raise NotImplementedError('This method is not yet supported.') 
 
@@ -239,6 +242,7 @@ class MilvusConnector:
         limit: int = 5,
         output_fields: Optional[list[str]] = None,
         metric_type: str = "COSINE",
+        filter_expr: Optional[str] = None, 
         search_params: Optional[dict[str, Any]] = None,
     ) -> list[list[dict]]:
         """
@@ -265,6 +269,7 @@ class MilvusConnector:
                 search_params=search_params,
                 limit=limit,
                 output_fields=output_fields,
+                filter=filter_expr
             )
             return results
         except Exception as e:


### PR DESCRIPTION
**Bug fix PR request**

- While working with the MCP server, I noticed the following:
    - The [milvus_vector_search](https://github.com/zilliztech/mcp-server-milvus/blob/main/src/mcp_server_milvus/server.py#L586) function was passing a `filter_expr` argument to the [vector_search](https://github.com/zilliztech/mcp-server-milvus/blob/main/src/mcp_server_milvus/server.py#L84-L104) function.
    - However, the function signature of vector_search did not actually accept this argument. This PR fixes that issue by updating the function definition accordingly.

- Additionally, for consistency:
    - I added the `filter_expr` parameter to both [hybrid_search](https://github.com/zilliztech/mcp-server-milvus/blob/main/src/mcp_server_milvus/server.py#L121) and [multi_vector_search](https://github.com/zilliztech/mcp-server-milvus/blob/main/src/mcp_server_milvus/server.py#L234).
    - These functions are not decorated with @mcp.tool, but the change ensures uniformity across all related functions.

Please review when you have a chance and let me know if any revisions are needed.
Thanks!