### PR TITLE
correct logical operator in create_collection index_params check

### DIFF
--- a/src/mcp_server_milvus/server.py
+++ b/src/mcp_server_milvus/server.py
@@ -273,7 +273,7 @@ class MilvusConnector:
                 schema = None
 
             built_index_params = MilvusClient.prepare_index_params()
-            if index_params is not None or len(index_params) > 0:
+            if index_params is not None and len(index_params) > 0:
                 for index_kwargs in index_params:
                     built_index_params.add_index(**index_kwargs)
 


### PR DESCRIPTION
## Summary
  - Fixed a logical bug in the `create_collection` method where `or` was incorrectly used instead of `and`
  when checking `index_params`

  ## Problem
  When calling `milvus_create_collection` without providing `index_params`, the function would fail with:
  Error: Failed to create collection: object of type 'NoneType' has no len()

  This was caused by the condition on line 276:
  ```python
  if index_params is not None or len(index_params) > 0:

  When index_params is None:
  - index_params is not None evaluates to False
  - Due to or, Python continues to evaluate len(index_params)
  - This causes TypeError because None has no len()
